### PR TITLE
Add checkbox for run a macro as a world script

### DIFF
--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -24,7 +24,9 @@
 			"runForEveryoneTooltip": "This will cause the macro to be executed by the GM for every players connected.\nFor security reasons, only applies to GM-created macros with no other owners.",
 			"runForSpecificUser": "Execute macro for specific user?",
 			"runForSpecificUserTooltip": "This will cause the macro to be executed by the GM for a specific player connected.\nFor security reasons, only applies to GM-created macros with no other owners.",
-			"none": "None"
+			"none": "None",
+			"runAsWorldScript": "Run as a world script",
+			"runAsWorldScriptTooltip": "Allow you to write a script in game which executes as if it was a world script."
 		},
 		"setting": {
 			"disableDropHotbarRollTableBehavior": {

--- a/src/scripts/lib/lib.js
+++ b/src/scripts/lib/lib.js
@@ -250,6 +250,11 @@ export function canRunAsGM(macro) {
 
 export function renderMacro(args, callFromSocket = false) {
 	const macro = this;
+	return renderMacroExplicit(macro, args, callFromSocket);
+}
+
+export function renderMacroExplicit(macro, args, callFromSocket = false) {
+	// const macro = this;
 	const context = getTemplateContext(args);
 	if (macro.type === "chat") {
 		if (macro.command.includes("{{")) {
@@ -578,25 +583,25 @@ export function renderMacroConfig(obj, html, data) {
 			</div>
 		`);
 		gmDiv.insertAfter(typeGroup);
-		/*
-		// Execute for all other clients (ty to socketlib)
+		
+		// Execute as a world script
 
-		const runForEveryone = macro.getFlag("advanced-macros", "runForEveryone");
-		const everyoneDiv = $(`
-		<div class="form-group" title="${game.i18n.localize("advanced-macros.MACROS.runForEveryoneTooltip")}">
+		const runAsWorldScript= macro.getFlag("advanced-macros", "runAsWorldScript");
+		const worldScriptDiv = $(`
+		<div class="form-group" title="${game.i18n.localize("advanced-macros.MACROS.runAsWorldScriptTooltip")}">
 			<label class="form-group">
-				<span>${game.i18n.localize("advanced-macros.MACROS.runForEveryone")}</span>
+				<span>${game.i18n.localize("advanced-macros.MACROS.runAsWorldScript")}</span>
 				<input type="checkbox"
-					name="flags.advanced-macros.runForEveryone"
+					name="flags.advanced-macros.runAsWorldScript"
 					data-dtype="Boolean"
-					${runForEveryone ? "checked" : ""}
+					${runAsWorldScript ? "checked" : ""}
 					${!canRunAsGMB ? "disabled" : ""}/>
 			</label>
 		</div>
 		`);
 
-		everyoneDiv.insertAfter(gmDiv);
-		*/
+		worldScriptDiv.insertAfter(gmDiv);
+		
 
 		// Exceute only for specific one
 		const runForSpecificUser = macro.getFlag("advanced-macros", "runForSpecificUser");
@@ -647,7 +652,7 @@ export function renderMacroConfig(obj, html, data) {
 			</div>
 		`);
 
-		specificOneDiv.insertAfter(gmDiv);
+		specificOneDiv.insertAfter(worldScriptDiv);
 	}
 }
 

--- a/src/scripts/module.js
+++ b/src/scripts/module.js
@@ -11,6 +11,9 @@ import {
 	renderMacroConfig,
 	_createContentLink,
 	_onClickContentLink,
+	error,
+	renderMacroExplicit,
+	info,
 } from "./lib/lib.js";
 import { advancedMacroSocket, registerSocket } from "./socket.js";
 
@@ -107,6 +110,19 @@ export const readyHooks = async () => {
 			});
 			return false;
 		});
+	}
+
+	if(game.user.isGM){
+		const macrosToRunAsWorldScript = game.macros.contents.filter((macro) => getProperty(macro, `flags.advanced-macros.runAsWorldScript`) === true); 
+		for(const macroWorldScript of macrosToRunAsWorldScript) {
+			try{
+				info(`Excecute world script : ` + macroWorldScript.name);
+				renderMacroExplicit(macroWorldScript);
+			}catch(err){
+				error(`Error on world script : ` + macroWorldScript.name);
+				error(err);
+			}
+		}
 	}
 };
 // ==========================================


### PR DESCRIPTION
This additional setting really helps people who are not "javascript handy", or those who have a set of macro world scripts that they always have to remember to run, or those like a friend of mine who need to specify to run world scripts only for specific players.

I don't think it compromises anything that has been developed for 10 or what you are preparing for 11.